### PR TITLE
Bug fixes for migrate-javaee-app-to-azure-training

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
           <runtime>
             <os>Linux</os>
             <javaVersion>Java 8</javaVersion>
-            <webContainer>Jbosseap 7.2</webContainer>
+            <webContainer>Jbosseap 7</webContainer>
           </runtime>
           <deployment>
             <resources>

--- a/src/main/java/org/agoncal/application/petstore/view/ViewUtils.java
+++ b/src/main/java/org/agoncal/application/petstore/view/ViewUtils.java
@@ -52,7 +52,7 @@ public final class ViewUtils
                   // Find a matching getter and invoke it to display the key
                   for (Method method : object.getClass().getDeclaredMethods())
                   {
-                     if (method.equals(new PropertyDescriptor(field.getName(), object.getClass()).getReadMethod()))
+                     if (method.equals(new PropertyDescriptor((String)field.getName(), object.getClass()).getReadMethod()))
                      {
                         return method.invoke(object).toString();
                      }

--- a/step-01-deploy-java-ee-app-to-azure/README.md
+++ b/step-01-deploy-java-ee-app-to-azure/README.md
@@ -8,9 +8,9 @@ Basics on configuring Maven and deploying a Java EE application to Azure.
 
 ## Verify Azure Subscription and setup development environment
 
-Set environment variables for storing Azure information, 
-particularly Azure Resource Group and Web app names. Then, you can 
-export them to your local environment. 
+Set environment variables for storing Azure information,
+particularly Azure Resource Group and Web app names. Then, you can
+export them to your local environment.
 
 You can start setting up environment variables using the supplied
 Bash shell script template.
@@ -19,7 +19,7 @@ Bash shell script template.
 cp setup-env-variables-template.sh .scripts/setup-env-variables.sh
 ```
 
-Modify `.scripts/setup-env-variables.sh` and set your Azure Resource Group name, 
+Modify `.scripts/setup-env-variables.sh` and set your Azure Resource Group name,
 Web app name, Azure Region, database name, database admin name and password.
 
 ```bash
@@ -55,8 +55,8 @@ az login # Sign into an azure account
 az account show # See the currently signed-in account.
 ```
 
-Ensure your default subscription is the one you intend to use for this lab, and if not - 
-set the subscription via 
+Ensure your default subscription is the one you intend to use for this lab, and if not -
+set the subscription via
 ```az account set --subscription ${SUBSCRIPTION}```.
 
 ## Build a Java EE application
@@ -69,7 +69,7 @@ mvn package -Dmaven.test.skip=true -Ddb=h2
 ---------------------------------------------------------------------
 [INFO] Building Petstore application using Java EE 7 7.0
 [INFO] ------------------------------------------------------------------------
-[INFO] 
+[INFO]
 ...
 [INFO] --- maven-war-plugin:3.1.0:war (default-war) @ petstoreee7 ---
 [INFO] Packaging webapp
@@ -87,14 +87,14 @@ mvn package -Dmaven.test.skip=true -Ddb=h2
 [INFO] ------------------------------------------------------------------------
 ```
 
-`pom.xml` in this repo is pre-configured to use the 
-[Maven Plugin for Azure App Service](https://github.com/Microsoft/azure-maven-plugins/blob/develop/azure-webapp-maven-plugin/README.md) - see XML fragment below. 
+`pom.xml` in this repo is pre-configured to use the
+[Maven Plugin for Azure App Service](https://github.com/Microsoft/azure-maven-plugins/blob/develop/azure-webapp-maven-plugin/README.md) - see XML fragment below.
 
-Note - you can also configure the same by executing 
+Note - you can also configure the same by executing
 `mvn com.microsoft.azure:azure-webapp-maven-plugin:1.16.1:config`.
 
-```xml    
-<plugins> 
+```xml
+<plugins>
 
   <!--*************************************************-->
   <!-- Deploy to JBoss EAP in App Service Linux           -->
@@ -109,12 +109,12 @@ Note - you can also configure the same by executing
       <subscriptionId>${SUBSCRIPTION}</subscriptionId>
       <resourceGroup>${RESOURCE_GROUP}</resourceGroup>
       <appName>${WEBAPP}</appName>
-      <pricingTier>P1v2</pricingTier>
+      <pricingTier>P1v3</pricingTier>
       <region>${REGION}</region>
       <runtime>
         <os>Linux</os>
         <javaVersion>Java 8</javaVersion>
-        <webContainer>Jbosseap 7.2</webContainer>
+        <webContainer>Jbosseap 7</webContainer>
       </runtime>
       <deployment>
         <resources>
@@ -131,7 +131,7 @@ Note - you can also configure the same by executing
     ...
 </plugins>
 ```
- 
+
 Deploy the Java EE application to App Service Linux:
 
 ```bash
@@ -140,11 +140,11 @@ mvn azure-webapp:deploy
 
 ```text
 [INFO] Scanning for projects...
-[INFO] 
+[INFO]
 [INFO] ------------------------------------------------------------------------
 [INFO] Building Petstore application using Java EE 7 7.0
 [INFO] ------------------------------------------------------------------------
-[INFO] 
+[INFO]
 [INFO] --- azure-webapp-maven-plugin:1.16.1:deploy (default-cli) @ petstoreee7 ---
 ...
 [INFO] Target Web App doesn't exist. Creating a new one...
@@ -173,8 +173,8 @@ open https://${WEBAPP}.azurewebsites.net
 ```
 ![](./media/YAPS-PetStore-H2.jpg)
 
-You can also `curl` the REST API exposed by the Java EE application. The admin REST 
-API allows you to create/update/remove items in the catalog, orders or customers. 
+You can also `curl` the REST API exposed by the Java EE application. The admin REST
+API allows you to create/update/remove items in the catalog, orders or customers.
 You can run the following curl commands:
 ```bash
 curl -X GET https://${WEBAPP}.azurewebsites.net/rest/categories


### PR DESCRIPTION
1. Fix the compile error on java 11
2. Fix the wrong pricing tier P1v2 in readme(the value in pom.xml is right)
3. Fix the runtime jboss 7.2 since portal has replace jboss 7.2 with jboss 7