### PR TITLE
Update Log4j to 2.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <version.javaee>7.0</version.javaee>
     <version.jboss-javaee>1.1.0.Final</version.jboss-javaee>
-    <version.log4j>2.8.2</version.log4j>
+    <version.log4j>2.15.0</version.log4j>
     <!-- Test -->
     <version.junit>4.12</version.junit>
     <version.arquillian>1.1.15.2</version.arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <properties>
     <version.javaee>7.0</version.javaee>
     <version.jboss-javaee>1.1.0.Final</version.jboss-javaee>
-    <version.log4j>2.15.0</version.log4j>
+    <version.log4j>2.16.0</version.log4j>
     <!-- Test -->
     <version.junit>4.12</version.junit>
     <version.arquillian>1.1.15.2</version.arquillian>


### PR DESCRIPTION
For the Log4J CVE. I tested this in my fork and the app builds correctly. It's running here on App Service with this change (using H2) http://eap-log4j-petstore-check.azurewebsites.net/applicationPetstore/shopping/main.xhtml

Corresponding PR in upstream: https://github.com/agoncal/agoncal-application-petstore-ee7/pull/25

- My fork: https://github.com/JasonFreeberg/migrate-javaee-app-to-azure-training
- My Build with 2.16.0: https://github.com/JasonFreeberg/migrate-javaee-app-to-azure-training/actions/runs/1584476453
- Live site: http://eap-log4j-petstore-check.azurewebsites.net/applicationPetstore/shopping/main.xhtml